### PR TITLE
Update Serilog packages to latest minor versions

### DIFF
--- a/Tetron.Mim.SynchronisationScheduler.csproj
+++ b/Tetron.Mim.SynchronisationScheduler.csproj
@@ -28,11 +28,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.Debug" Version="2.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="System.Management.Automation.dll" Version="10.0.10586" />
+    <PackageReference Include="Serilog" Version="2.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.*" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="2.*" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Using wildcard versioning to stay within same major versions:
- Serilog 2.10.0 → 2.12.0 (latest in 2.x)
- Serilog.Sinks.* already at latest within their major versions

This approach ensures we get bug fixes and minor improvements while avoiding breaking changes from major version updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)